### PR TITLE
Fix shortcut callbacks dropping under repeated keypresses

### DIFF
--- a/Stark/Features/Events/Event.swift
+++ b/Stark/Features/Events/Event.swift
@@ -8,21 +8,19 @@ class Event: NSObject {
     "<Event id: \(id), event: \(event)>"
   }
 
-  private var callback: JSManagedValue?
+  private var callback: JSValue?
 
   init(event: String) {
     self.event = event
     self.id = UUID().uuidString
   }
 
-  init(event: String, callback: JSValue, callbackOwner: AnyObject) {
+  init(event: String, callback: JSValue) {
     self.event = event
     self.id = UUID().uuidString
-    self.callback = JSManagedValue(value: callback, andOwner: callbackOwner)
+    self.callback = callback
 
     super.init()
-
-    JSCallbackInvoker.addManagedReference(for: self, callback: callback, owner: callbackOwner)
   }
 
   deinit {
@@ -31,9 +29,5 @@ class Event: NSObject {
 
   func call(withArguments args: [Any]) {
     JSCallbackInvoker.call(callback, withArguments: args)
-  }
-
-  func detachCallback(from owner: AnyObject) {
-    JSCallbackInvoker.removeManagedReference(for: self, callback: callback, owner: owner)
   }
 }

--- a/Stark/Features/Shortcuts/Keymap.swift
+++ b/Stark/Features/Shortcuts/Keymap.swift
@@ -17,18 +17,17 @@ class Keymap: NSObject {
   var modifiers: [String]
 
   private var shortcut: Shortcut?
-  private var callback: JSManagedValue?
+  private var callback: JSValue?
 
-  init(key: String, modifiers: [String], callback: JSValue, callbackOwner: AnyObject) {
+  init(key: String, modifiers: [String], callback: JSValue) {
     self.key = key
     self.modifiers = modifiers
-    shortcut = Shortcut(key: key, modifiers: modifiers)
-    self.callback = JSManagedValue(value: callback, andOwner: callbackOwner)
+    self.callback = callback
 
     super.init()
 
+    shortcut = Shortcut(key: key, modifiers: modifiers)
     shortcut?.handler = call
-    JSCallbackInvoker.addManagedReference(for: self, callback: callback, owner: callbackOwner)
   }
 
   deinit {
@@ -43,10 +42,6 @@ class Keymap: NSObject {
   func deactivate(with shortcutManager: ShortcutManager) {
     guard let shortcut else { return }
     shortcutManager.unregister(shortcut: shortcut)
-  }
-
-  func detachCallback(from owner: AnyObject) {
-    JSCallbackInvoker.removeManagedReference(for: self, callback: callback, owner: owner)
   }
 
   private func call() {

--- a/Stark/Features/Shortcuts/ShortcutManager.swift
+++ b/Stark/Features/Shortcuts/ShortcutManager.swift
@@ -14,6 +14,8 @@ final class ShortcutManager {
   private static let defaultHandlerInvoker: HandlerInvoker = { handler in
     DispatchQueue.main.async(execute: handler)
   }
+  private static let invocationLock = NSLock()
+  private static var activeInvocationID: UUID?
 
   private var shortcutsByKeyCode = [UInt32: [Shortcut]]()
   private var shortcutByIdentifier = [UUID: Shortcut]()
@@ -21,6 +23,8 @@ final class ShortcutManager {
   private var tap: ShortcutTapType?
   private var tapFactory: TapFactory?
   private var handlerInvoker = defaultHandlerInvoker
+  private let pendingLock = NSLock()
+  private var pendingInvocationID: UUID?
 
   init(
     tapFactory: TapFactory? = nil,
@@ -79,7 +83,12 @@ final class ShortcutManager {
     guard let matchedShortcut = matchingShortcut(for: keyCode, flags: flags) else { return false }
 
     if let handler = matchedShortcut.handler {
-      handlerInvoker(handler)
+      guard beginInvocation(for: matchedShortcut.identifier) else {
+        recordPendingInvocation(for: matchedShortcut.identifier)
+        return true
+      }
+
+      dispatchInvocation(for: matchedShortcut.identifier, handler: handler)
     }
 
     return true
@@ -115,7 +124,8 @@ final class ShortcutManager {
   }
 
   private func handleTapDisabled(_ event: CGEvent) -> Unmanaged<CGEvent> {
-    tap?.enable(true)
+    tearDownTap()
+    ensureTapState()
     return Unmanaged.passUnretained(event)
   }
 
@@ -162,6 +172,9 @@ final class ShortcutManager {
     guard let shortcut = shortcutByIdentifier.removeValue(forKey: identifier) else { return }
     guard let shortcuts = shortcutsByKeyCode[shortcut.keyCode] else { return }
 
+    finishInvocation(for: identifier)
+    clearPendingInvocation(for: identifier)
+
     let remainingShortcuts = shortcuts.filter { shortcut in
       shortcut.identifier != identifier
     }
@@ -171,5 +184,82 @@ final class ShortcutManager {
     } else {
       shortcutsByKeyCode[shortcut.keyCode] = remainingShortcuts
     }
+  }
+
+  private func beginInvocation(for identifier: UUID) -> Bool {
+    Self.invocationLock.lock()
+    defer { Self.invocationLock.unlock() }
+
+    if Self.activeInvocationID != nil {
+      return false
+    }
+
+    Self.activeInvocationID = identifier
+    return true
+  }
+
+  private func finishInvocation(for identifier: UUID) {
+    Self.invocationLock.lock()
+    if Self.activeInvocationID == identifier {
+      Self.activeInvocationID = nil
+    }
+    Self.invocationLock.unlock()
+  }
+
+  private func dispatchInvocation(for identifier: UUID, handler: @escaping () -> Void) {
+    handlerInvoker { [weak self] in
+      defer { self?.completeInvocation(for: identifier) }
+      handler()
+    }
+  }
+
+  private func completeInvocation(for identifier: UUID) {
+    finishInvocation(for: identifier)
+    dispatchPendingInvocation()
+  }
+
+  private func dispatchPendingInvocation() {
+    while let identifier = takePendingInvocation() {
+      guard beginInvocation(for: identifier) else {
+        recordPendingInvocation(for: identifier)
+        return
+      }
+
+      guard let handler = shortcutByIdentifier[identifier]?.handler else {
+        finishInvocation(for: identifier)
+        continue
+      }
+
+      dispatchInvocation(for: identifier, handler: handler)
+      return
+    }
+  }
+
+  private func recordPendingInvocation(for identifier: UUID) {
+    pendingLock.lock()
+    pendingInvocationID = identifier
+    pendingLock.unlock()
+  }
+
+  private func takePendingInvocation() -> UUID? {
+    pendingLock.lock()
+    let identifier = pendingInvocationID
+    pendingInvocationID = nil
+    pendingLock.unlock()
+    return identifier
+  }
+
+  private func clearPendingInvocation(for identifier: UUID) {
+    pendingLock.lock()
+    if pendingInvocationID == identifier {
+      pendingInvocationID = nil
+    }
+    pendingLock.unlock()
+  }
+
+  static func resetInvocationStateForTesting() {
+    invocationLock.lock()
+    activeInvocationID = nil
+    invocationLock.unlock()
   }
 }

--- a/Stark/Scripting/Config/ConfigManager.swift
+++ b/Stark/Scripting/Config/ConfigManager.swift
@@ -67,16 +67,6 @@ final class ConfigSession {
     }
 
     shortcutManager = nil
-
-    for keymap in keymapsByID.values {
-      keymap.detachCallback(from: self)
-    }
-
-    for listeners in listenersByEvent.values {
-      for listener in listeners {
-        listener.detachCallback(from: self)
-      }
-    }
   }
 
   @discardableResult
@@ -84,16 +74,13 @@ final class ConfigSession {
     let keymap = Keymap(
       key: key,
       modifiers: modifiers,
-      callback: callback,
-      callbackOwner: self
+      callback: callback
     )
 
     if let previous = keymapsByID.updateValue(keymap, forKey: keymap.id) {
       if let shortcutManager {
         previous.deactivate(with: shortcutManager)
       }
-
-      previous.detachCallback(from: self)
     }
 
     if let shortcutManager {
@@ -109,8 +96,6 @@ final class ConfigSession {
     if let shortcutManager {
       keymap.deactivate(with: shortcutManager)
     }
-
-    keymap.detachCallback(from: self)
   }
 
   func resetKeymaps() {
@@ -122,10 +107,6 @@ final class ConfigSession {
         keymap.deactivate(with: shortcutManager)
       }
     }
-
-    for keymap in keymaps {
-      keymap.detachCallback(from: self)
-    }
   }
 
   @discardableResult
@@ -135,7 +116,7 @@ final class ConfigSession {
       return Event(event: event)
     }
 
-    let listener = Event(event: event, callback: callback, callbackOwner: self)
+    let listener = Event(event: event, callback: callback)
     listenersByEvent[eventType, default: []].append(listener)
 
     return listener
@@ -144,20 +125,11 @@ final class ConfigSession {
   func removeEvent(_ event: String) {
     guard let eventType = EventType(rawValue: event) else { return }
 
-    let listeners = listenersByEvent.removeValue(forKey: eventType) ?? []
-
-    for listener in listeners {
-      listener.detachCallback(from: self)
-    }
+    listenersByEvent.removeValue(forKey: eventType)
   }
 
   func resetEvents() {
-    let listeners = listenersByEvent.values.flatMap { $0 }
     listenersByEvent.removeAll()
-
-    for listener in listeners {
-      listener.detachCallback(from: self)
-    }
   }
 
   func callbacks(for event: EventType) -> [Event] {

--- a/Stark/Scripting/JavaScript/JSCallbackInvoker.swift
+++ b/Stark/Scripting/JavaScript/JSCallbackInvoker.swift
@@ -1,18 +1,8 @@
 import JavaScriptCore
 
 enum JSCallbackInvoker {
-  static func addManagedReference(for object: AnyObject, callback: JSValue, owner: Any) {
-    callback.context.virtualMachine.addManagedReference(object, withOwner: owner)
-  }
-
-  static func removeManagedReference(for object: AnyObject, callback: JSManagedValue?, owner: Any) {
-    guard let callback = callback?.value else { return }
-
-    callback.context.virtualMachine.removeManagedReference(object, withOwner: owner)
-  }
-
-  static func call(_ callback: JSManagedValue?, withArguments arguments: [Any]) {
-    guard let callback = callback?.value else { return }
+  static func call(_ callback: JSValue?, withArguments arguments: [Any]) {
+    guard let callback else { return }
     guard let context = callback.context else { return }
 
     let previousExceptionHandler = context.exceptionHandler

--- a/StarkTests/Features/Shortcuts/KeymapTests.swift
+++ b/StarkTests/Features/Shortcuts/KeymapTests.swift
@@ -189,6 +189,7 @@ private final class TestShortcutTapRecorder {
   private func prepareState() -> (
     ShortcutManager, TestShortcutTapRecorder, ConfigSession, CallbackState
   ) {
+    ShortcutManager.resetInvocationStateForTesting()
     let tapRecorder = TestShortcutTapRecorder()
     let manager = ShortcutManager(
       tapFactory: tapRecorder.makeTap(),

--- a/StarkTests/Features/Shortcuts/ShortcutManagerTests.swift
+++ b/StarkTests/Features/Shortcuts/ShortcutManagerTests.swift
@@ -349,7 +349,7 @@ private final class RecordingShortcutTapRecorder {
     #expect(tapRecorder.invalidateCallCount == 1)
   }
 
-  @Test func tapDisabledEventsReEnableActiveTap() {
+  @Test func tapDisabledEventsRecreateActiveTap() {
     let (manager, tapRecorder) = prepareManager()
 
     manager.register(shortcut: shortcut(id: "A"))
@@ -358,9 +358,9 @@ private final class RecordingShortcutTapRecorder {
     let event = keyDownEvent(keyCode: UInt32(kVK_Return), flags: eventFlags([.maskCommand]))
 
     _ = tapRecorder.eventHandler?(.tapDisabledByTimeout, event)
-    _ = tapRecorder.eventHandler?(.tapDisabledByUserInput, event)
 
-    #expect(tapRecorder.enableCalls == [true, true])
+    #expect(tapRecorder.invalidateCallCount == 1)
+    #expect(tapRecorder.createCallCount == 2)
   }
 
   @Test func eventTapCallbackSwallowsMatchedShortcut() {
@@ -396,11 +396,117 @@ private final class RecordingShortcutTapRecorder {
     #expect(callCount == 1)
   }
 
+  @Test func repeatedMatchesDoNotQueueWhileHandlerIsStillPending() {
+    ShortcutManager.resetInvocationStateForTesting()
+    let tapRecorder = RecordingShortcutTapRecorder()
+    var queuedHandlers = [() -> Void]()
+    var callCount = 0
+    let manager = ShortcutManager(
+      tapFactory: tapRecorder.makeTap(),
+      handlerInvoker: { handler in
+        queuedHandlers.append(handler)
+      }
+    )
+
+    manager.register(shortcut: shortcut(id: "A", handler: { callCount += 1 }))
+    manager.start()
+
+    #expect(dispatchKeyDown(with: tapRecorder) == nil)
+    #expect(dispatchKeyDown(with: tapRecorder) == nil)
+    #expect(queuedHandlers.count == 1)
+    #expect(callCount == 0)
+
+    let firstHandler = queuedHandlers.removeFirst()
+    firstHandler()
+
+    #expect(callCount == 1)
+    #expect(queuedHandlers.count == 1)
+
+    let secondHandler = queuedHandlers.removeFirst()
+    secondHandler()
+
+    #expect(callCount == 2)
+  }
+
+  @Test func alternatingMatchesCoalesceLatestWhileHandlerIsStillPending() {
+    ShortcutManager.resetInvocationStateForTesting()
+    let tapRecorder = RecordingShortcutTapRecorder()
+    var queuedHandlers = [() -> Void]()
+    var firstCallCount = 0
+    var secondCallCount = 0
+    let manager = ShortcutManager(
+      tapFactory: tapRecorder.makeTap(),
+      handlerInvoker: { handler in
+        queuedHandlers.append(handler)
+      }
+    )
+
+    manager.register(shortcut: shortcut(id: "A", keyCode: 4, handler: { firstCallCount += 1 }))
+    manager.register(shortcut: shortcut(id: "B", keyCode: 37, handler: { secondCallCount += 1 }))
+    manager.start()
+
+    #expect(dispatchKeyDown(with: tapRecorder, keyCode: 4) == nil)
+    #expect(dispatchKeyDown(with: tapRecorder, keyCode: 37) == nil)
+    #expect(queuedHandlers.count == 1)
+    #expect(firstCallCount == 0)
+    #expect(secondCallCount == 0)
+
+    let firstHandler = queuedHandlers.removeFirst()
+    firstHandler()
+
+    #expect(firstCallCount == 1)
+    #expect(secondCallCount == 0)
+    #expect(queuedHandlers.count == 1)
+
+    let secondHandler = queuedHandlers.removeFirst()
+    secondHandler()
+
+    #expect(firstCallCount == 1)
+    #expect(secondCallCount == 1)
+  }
+
+  @Test func pendingInvocationKeepsOnlyLatestShortcut() {
+    ShortcutManager.resetInvocationStateForTesting()
+    let tapRecorder = RecordingShortcutTapRecorder()
+    var queuedHandlers = [() -> Void]()
+    var firstCallCount = 0
+    var secondCallCount = 0
+    let manager = ShortcutManager(
+      tapFactory: tapRecorder.makeTap(),
+      handlerInvoker: { handler in
+        queuedHandlers.append(handler)
+      }
+    )
+
+    manager.register(shortcut: shortcut(id: "A", keyCode: 4, handler: { firstCallCount += 1 }))
+    manager.register(shortcut: shortcut(id: "B", keyCode: 37, handler: { secondCallCount += 1 }))
+    manager.start()
+
+    #expect(dispatchKeyDown(with: tapRecorder, keyCode: 4) == nil)
+    #expect(dispatchKeyDown(with: tapRecorder, keyCode: 37) == nil)
+    #expect(dispatchKeyDown(with: tapRecorder, keyCode: 4) == nil)
+    #expect(queuedHandlers.count == 1)
+
+    let firstHandler = queuedHandlers.removeFirst()
+    firstHandler()
+
+    #expect(firstCallCount == 1)
+    #expect(secondCallCount == 0)
+    #expect(queuedHandlers.count == 1)
+
+    let latestPendingHandler = queuedHandlers.removeFirst()
+    latestPendingHandler()
+
+    #expect(firstCallCount == 2)
+    #expect(secondCallCount == 0)
+  }
+
   private func prepareManager(
     handlerInvoker: @escaping ShortcutManager.HandlerInvoker = { handler in
       DispatchQueue.main.async(execute: handler)
     }
   ) -> (ShortcutManager, RecordingShortcutTapRecorder) {
+    ShortcutManager.resetInvocationStateForTesting()
     let tapRecorder = RecordingShortcutTapRecorder()
     let manager = ShortcutManager(
       tapFactory: tapRecorder.makeTap(),


### PR DESCRIPTION
## Summary
- retain JavaScript callbacks directly on registered keymaps and event listeners so shortcut handlers are not released while still in use
- coalesce in-flight shortcut invocations so repeated keypresses do not wedge or starve later shortcut handling
- recreate disabled shortcut taps and add focused tests for repeated keypress and callback-retention behavior

## Testing
- `xcodebuild test -project Stark.xcodeproj -scheme Stark -only-testing:StarkTests/ShortcutManagerTests -only-testing:StarkTests/KeymapTests CODE_SIGNING_ALLOWED=NO`
